### PR TITLE
Fix: Ensure exam questions are loaded for students

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -69,7 +69,7 @@ class Exam(db.Model):
     passing_score = db.Column(db.Integer, default=70)
     negative_marking = db.Column(db.Boolean, default=False)
     randomize_questions = db.Column(db.Boolean, default=True)
-    questions = db.relationship('Question', secondary=exam_questions, lazy='subquery',
+    questions = db.relationship('Question', secondary=exam_questions, lazy='joined',
                                 backref=db.backref('exams', lazy=True))
     results = db.relationship('Result', backref='exam', lazy=True, cascade="all, delete-orphan")
 


### PR DESCRIPTION
This commit fixes an issue where students would see a broken exam page with no questions or countdown timer.

The root cause of the issue was that the questions for an exam were not being loaded reliably when a student tried to take an exam. This was likely due to an issue with the `lazy='subquery'` loading strategy on the `exam.questions` relationship in the `Exam` model.

This commit changes the loading strategy to `lazy='joined'`. This ensures that the questions are loaded in the same database query as the exam, which is a more reliable way of fetching the data. This will prevent the `exam.questions` list from being empty and will allow the exam page to be rendered correctly for students.